### PR TITLE
Add asset usage list to asset details view

### DIFF
--- a/application/config/module.config.php
+++ b/application/config/module.config.php
@@ -338,7 +338,6 @@ return [
             'Omeka\Controller\Site\ItemSet' => Controller\Site\ItemSetController::class,
             'Omeka\Controller\Site\Media' => Controller\Site\MediaController::class,
             'Omeka\Controller\Site\CrossSiteSearch' => Controller\Site\CrossSiteSearchController::class,
-            'Omeka\Controller\Admin\Asset' => Controller\Admin\AssetController::class,
             'Omeka\Controller\Admin\Query' => Controller\Admin\QueryController::class,
             'Omeka\Controller\Admin\Columns' => Controller\Admin\ColumnsController::class,
             'Omeka\Controller\Admin\ItemSet' => Controller\Admin\ItemSetController::class,
@@ -350,6 +349,7 @@ return [
             'Omeka\Controller\SiteAdmin\Page' => Controller\SiteAdmin\PageController::class,
         ],
         'factories' => [
+            'Omeka\Controller\Admin\Asset' => Service\Controller\Admin\AssetControllerFactory::class,
             'Omeka\Controller\Login' => Service\Controller\LoginControllerFactory::class,
             'Omeka\Controller\Api' => Service\Controller\ApiControllerFactory::class,
             'Omeka\Controller\ApiLocal' => Service\Controller\ApiLocalControllerFactory::class,
@@ -457,6 +457,7 @@ return [
             'iiifViewer' => View\Helper\IiifViewer::class,
             'currentSite' => View\Helper\CurrentSite::class,
             'formSelectSort' => Form\View\Helper\FormSelectSort::class,
+            'relatedResourcesToAsset' => View\Helper\RelatedResourcesToAsset::class,
         ],
         'factories' => [
             'api' => Service\ViewHelper\ApiFactory::class,

--- a/application/src/Controller/Admin/AssetController.php
+++ b/application/src/Controller/Admin/AssetController.php
@@ -4,6 +4,9 @@ namespace Omeka\Controller\Admin;
 use Omeka\Api\Exception\ValidationException;
 use Omeka\Form\AssetEditForm;
 use Omeka\Form\ConfirmForm;
+
+use Doctrine\ORM\EntityManager;
+
 use RecursiveArrayIterator;
 use RecursiveIteratorIterator;
 use Laminas\View\Model\ViewModel;
@@ -11,6 +14,19 @@ use Laminas\Mvc\Controller\AbstractActionController;
 
 class AssetController extends AbstractActionController
 {
+    /**
+     * @var EntityManager
+     */
+    protected $entityManager;
+
+    /**
+     * @param EntityManager $entityManager
+     */
+    public function __construct(EntityManager $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
     public function browseAction()
     {
         $this->browse()->setDefaults('assets');
@@ -26,10 +42,15 @@ class AssetController extends AbstractActionController
     public function showDetailsAction()
     {
         $response = $this->api()->read('assets', $this->params('id'));
+        $asset = $response->getContent();
 
         $view = new ViewModel;
         $view->setTerminal(true);
-        $view->setVariable('resource', $response->getContent());
+        $view->setVariable('resource', $asset);
+
+        $assetId = $asset->id();
+        $resourceArray = $this->getRelatedResources($assetId);
+        $view->setVariable('resource_array', $resourceArray);
         return $view;
     }
 
@@ -116,12 +137,17 @@ class AssetController extends AbstractActionController
     public function deleteConfirmAction()
     {
         $resource = $this->api()->read('assets', $this->params('id'))->getContent();
+        $assetId = $resource->id();
 
         $view = new ViewModel;
         $view->setTerminal(true);
         $view->setTemplate('common/delete-confirm-details');
         $view->setVariable('resource', $resource);
         $view->setVariable('resourceLabel', 'asset'); // @translate
+
+        $resourceArray = $this->getRelatedResources($assetId);
+        $view->setVariable('resource_array', $resourceArray);
+
         $view->setVariable('partialPath', 'omeka/admin/asset/show-details');
         return $view;
     }
@@ -145,5 +171,15 @@ class AssetController extends AbstractActionController
             ['action' => 'browse'],
             true
         );
+    }
+
+    public function getRelatedResources($id)
+    {
+        $dql = 'SELECT r FROM Omeka\Entity\Resource r WHERE r.thumbnail = :id';
+        $query = $this->entityManager->createQuery($dql)
+            ->setParameter('id', $id);
+
+        $resourceArray = $query->getResult();
+        return $resourceArray;
     }
 }

--- a/application/src/Service/Controller/Admin/AssetControllerFactory.php
+++ b/application/src/Service/Controller/Admin/AssetControllerFactory.php
@@ -1,0 +1,16 @@
+<?php
+namespace Omeka\Service\Controller\Admin;
+
+use Interop\Container\ContainerInterface;
+use Omeka\Controller\Admin\AssetController;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class AssetControllerFactory implements FactoryInterface
+{
+    public function __invoke(ContainerInterface $services, $requestedName, ?array $options = null)
+    {
+        return new AssetController(
+            $services->get('Omeka\EntityManager')
+        );
+    }
+}

--- a/application/src/View/Helper/RelatedResourcesToAsset.php
+++ b/application/src/View/Helper/RelatedResourcesToAsset.php
@@ -1,0 +1,24 @@
+<?php
+namespace Omeka\View\Helper;
+
+use Laminas\View\Helper\AbstractHelper;
+
+/**
+ * View helper for getting resources Id, type and resource_type as an array
+ */
+class RelatedResourcesToAsset extends AbstractHelper
+{
+    /**
+     * @param array $resources
+     * @return string
+     */
+    public function __invoke($resources = null)
+    {
+        return $this->getView()->partial(
+            'common/related-resources-to-asset',
+            [
+                'resources' => $resources,
+            ]
+        );
+    }
+}

--- a/application/view/common/related-resources-to-asset.phtml
+++ b/application/view/common/related-resources-to-asset.phtml
@@ -1,0 +1,49 @@
+<?php
+$translate = $this->plugin('translate');
+$hyperlink = $this->plugin('hyperlink');
+$escape = $this->plugin('escapeHtml');
+
+$mappedResource = [
+    'labels' => [
+        'items' => 'item',
+        'item_sets' => 'item-set',
+    ],
+    
+    'display_titles' => [
+        'item' => 'Items',
+        'item-set' => 'Item sets',
+        'media' => 'Media',
+    ]
+];
+
+$results = [];
+
+foreach ($resources as $resource) {
+
+    $type = isset($mappedResource['labels'][$resource->getResourceName()]) ? $mappedResource['labels'][$resource->getResourceName()] : $resource->getResourceName();
+
+    $title = $resource->getTitle();
+    $id = $resource->getId();
+
+    $output =  $hyperlink($title . '(' . $id . ')', $this->url('admin/default', ['controller' => $type, 'action' => 'browse'], ['query' => ['id' => $id]]));
+    $results[$type][] = $output;
+}
+?>
+
+<?php foreach ($results as $type => $values): ?>
+    
+    <div class="value">
+        <?php if(isset($mappedResource['display_titles'][$type])): ?>
+            <?= $escape($translate($mappedResource['display_titles'][$type]));?>
+        <?php else: ?>
+            <?= $escape($translate($type));?>
+        <?php endif; ?>
+    </div> 
+
+    <div class="value">
+        <?php foreach ($values as $value): ?>
+            <?= $value ?><br>
+        <?php endforeach; ?>
+    </div>
+    
+<?php endforeach; ?>

--- a/application/view/omeka/admin/asset/show-details.phtml
+++ b/application/view/omeka/admin/asset/show-details.phtml
@@ -3,10 +3,17 @@ $translate = $this->plugin('translate');
 $escape = $this->plugin('escapeHtml');
 ?>
 <h3>
-    <?php echo $escape($resource->name()); ?>
+    <?php echo $escape($resource->name());?>
 </h3>
 
 <?php echo $this->thumbnail($resource, 'square', ['class' => 'asset-inline']); ?>
+
+<?php if ($resource_array): ?> 
+    <div class="meta-group">
+        <h4><?php echo $translate('Related to:'); ?></h4>
+        <?php  echo $this->relatedResourcesToAsset($resource_array); ?>
+    </div>
+<?php endif; ?>
 
 <div class="meta-group">
     <h4><?php echo $translate('Media type'); ?></h4>


### PR DESCRIPTION
  ## Description

This PR adds an asset usage section to the admin asset's `show-details` and `delete` views.

It lists the resources that use the current asset as a thumbnail, displaying their name and ID as hyperlinks to the corresponding resource.

This makes it easier to identify where an asset is used and helps prevent the deletion of assets that are still in use.
